### PR TITLE
Test failure fixes

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -30,5 +30,5 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Run all tests
       run: |
-        python3 manage.py test
+        python3 manage.py test -v 3 >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -33,5 +33,5 @@ jobs:
         echo "SECRET_KEY=123" > .env
     - name: Run all tests
       run: |
-        python3 manage.py test -v 3 >> "$GITHUB_OUTPUT"
+        python3 manage.py test
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,6 +28,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Create a .env file
+      run: |
+        echo "SECRET_KEY=123" > .env
     - name: Run all tests
       run: |
         python3 manage.py test -v 3 >> "$GITHUB_OUTPUT"

--- a/my_api/settings.py
+++ b/my_api/settings.py
@@ -24,8 +24,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # SECURITY WARNING: keep the secret key used in production secret!
 env = Env()
 env_path = Path(__file__).resolve().parent.parent / ".env"
-env.read_env(recurse=True, path=str(env_path), verbose=True)
-print(__debug__)
+env.read_env(str(env_path), False)
 SECRET_KEY = env.str("SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!

--- a/my_api/settings.py
+++ b/my_api/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 """
 
 from pathlib import Path
+
 from environs import Env
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -22,7 +23,9 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 # SECURITY WARNING: keep the secret key used in production secret!
 env = Env()
-env.read_env()
+env_path = Path(__file__).resolve().parent.parent / ".env"
+env.read_env(recurse=True, path=str(env_path), verbose=True)
+print(__debug__)
 SECRET_KEY = env.str("SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!

--- a/solax_registers/tests.py
+++ b/solax_registers/tests.py
@@ -1,15 +1,29 @@
 """File of API tests."""
 
+from pathlib import Path
+import sys
+
+env_path = Path(__file__).resolve().parent.parent / ".env"
+
+if not env_path.exists():
+    with open(str(env_path), "w", encoding="utf-8") as f:
+        f.write("SECRET_KEY=your_key")
+
 from django.contrib.auth import get_user_model
+from django.test import override_settings
 from django.urls import reverse_lazy
 from rest_framework.status import HTTP_200_OK, HTTP_201_CREATED, HTTP_400_BAD_REQUEST
 from rest_framework.test import APITestCase
 
 from .models import DailyStatsRecord, LastDayStatsRecord
 
+
 User = get_user_model()
 
 
+@override_settings(
+    SECRET_KEY="django-insecure-o$ax$#*gng6qi*j#&9lwof070#f=v^7e9ck)_70@t60kppj&hz"
+)
 class AddHistoryStatsTests(APITestCase):
     """Tests for adding history stats."""
 
@@ -151,6 +165,9 @@ class AddHistoryStatsTests(APITestCase):
         self.assertEqual(DailyStatsRecord.objects.count(), 0)
 
 
+@override_settings(
+    SECRET_KEY="django-insecure-o$ax$#*gng6qi*j#&9lwof070#f=v^7e9ck)_70@t60kppj&hz"
+)
 class GetHistoryStatsTests(APITestCase):
     """Tests for getting history stats."""
 
@@ -289,6 +306,9 @@ class GetHistoryStatsTests(APITestCase):
         self.assertListEqual(response.json(), result)
 
 
+@override_settings(
+    SECRET_KEY="django-insecure-o$ax$#*gng6qi*j#&9lwof070#f=v^7e9ck)_70@t60kppj&hz"
+)
 class DeleteHistoryStatsTests(APITestCase):
     """Tests to test deleting history tests."""
 
@@ -369,6 +389,9 @@ class DeleteHistoryStatsTests(APITestCase):
         self.assertEqual(response.json(), result)
 
 
+@override_settings(
+    SECRET_KEY="django-insecure-o$ax$#*gng6qi*j#&9lwof070#f=v^7e9ck)_70@t60kppj&hz"
+)
 class AddLastHistoryStatsTests(APITestCase):
     """Tests for adding last history stats."""
 
@@ -450,6 +473,9 @@ class AddLastHistoryStatsTests(APITestCase):
         self.assertListEqual(sorted(extra_fields), ["extra_field"])
 
 
+@override_settings(
+    SECRET_KEY="django-insecure-o$ax$#*gng6qi*j#&9lwof070#f=v^7e9ck)_70@t60kppj&hz"
+)
 class GetLastHistoryStatsTests(APITestCase):
     """Tests for getting last history stats."""
 

--- a/solax_registers/tests.py
+++ b/solax_registers/tests.py
@@ -1,14 +1,5 @@
 """File of API tests."""
 
-from pathlib import Path
-import sys
-
-env_path = Path(__file__).resolve().parent.parent / ".env"
-
-if not env_path.exists():
-    with open(str(env_path), "w", encoding="utf-8") as f:
-        f.write("SECRET_KEY=your_key")
-
 from django.contrib.auth import get_user_model
 from django.test import override_settings
 from django.urls import reverse_lazy


### PR DESCRIPTION
Tried to fix the test failure when `.env` is missing.
However, it is not possible to overcome that problem, so I had to create the file manually in the build.