### PR TITLE
Renamed a delete query parameter

### DIFF
--- a/my_api/settings.py
+++ b/my_api/settings.py
@@ -112,8 +112,8 @@ REST_FRAMEWORK = {
 }
 
 SPECTACULAR_SETTINGS = {
-    "TITLE": "Solax API",
-    "DESCRIPTION": "An API storing and retrieving data from various sources.",
-    "VERSION": "0.1.2",
+    "TITLE": "SolaxX3 API",
+    "DESCRIPTION": "An API storing and retrieving data from a SolaxX3 inverter.",
+    "VERSION": "0.1.3",
     "SERVE_INCLUDE_SCHEMA": False,
 }

--- a/solax_registers/create_views.py
+++ b/solax_registers/create_views.py
@@ -326,18 +326,18 @@ def create_views(
                 "delete_older_than": self._delete_older_than_date,
                 "truncate": self._truncate,
             }
-            mode = request.query_params.get("action")
+            action = request.query_params.get("action")
             args = request.query_params.getlist("args")
 
-            if not mode:
+            if not action:
                 MESSAGE = "Non-null query parameter 'action' is mandatory."
                 return Response({"detail": MESSAGE}, status.HTTP_400_BAD_REQUEST)
 
-            if mode not in MODE_ACTION_MAPPING:
-                MESSAGE = "Query parameter 'action' is not among valid modes."
+            if action not in MODE_ACTION_MAPPING:
+                MESSAGE = "Query parameter 'action' is not among valid actions."
                 return Response({"detail": MESSAGE}, status.HTTP_400_BAD_REQUEST)
 
-            return MODE_ACTION_MAPPING[mode](args)
+            return MODE_ACTION_MAPPING[action](args)
 
         def _delete_older_than_date(self, args: list) -> Response:
             if args == []:

--- a/solax_registers/create_views.py
+++ b/solax_registers/create_views.py
@@ -155,7 +155,7 @@ def create_views(
     POST_PARAMETERS = [OVERWRITE_PARAM]
 
     MODE_PARAM = OpenApiParameter(
-        name="mode",
+        name="action",
         enum=["delete_older_than", "truncate"],
         location="query",
         required=True,
@@ -168,7 +168,7 @@ def create_views(
                 value="delete_older_than",
                 summary="Using delete_older_than",
                 description="Use delete_older_than to delete records"
-                " older than X date.",
+                " older than the given date.",
             ),
             OpenApiExample(
                 name="Ex. 2",
@@ -326,15 +326,15 @@ def create_views(
                 "delete_older_than": self._delete_older_than_date,
                 "truncate": self._truncate,
             }
-            mode = request.query_params.get("mode")
+            mode = request.query_params.get("action")
             args = request.query_params.getlist("args")
 
             if not mode:
-                MESSAGE = "Non-null query parameter 'mode' is mandatory."
+                MESSAGE = "Non-null query parameter 'action' is mandatory."
                 return Response({"detail": MESSAGE}, status.HTTP_400_BAD_REQUEST)
 
             if mode not in MODE_ACTION_MAPPING:
-                MESSAGE = "Query parameter 'mode' is not among valid modes."
+                MESSAGE = "Query parameter 'action' is not among valid modes."
                 return Response({"detail": MESSAGE}, status.HTTP_400_BAD_REQUEST)
 
             return MODE_ACTION_MAPPING[mode](args)

--- a/solax_registers/tests.py
+++ b/solax_registers/tests.py
@@ -320,24 +320,24 @@ class DeleteHistoryStatsTests(APITestCase):
         DailyStatsRecord(upload_date="2021-01-01").save()
         DailyStatsRecord(upload_date="2022-01-01").save()
 
-    def test_deleting_with_no_mode(self):
-        """Try to delete data without passing the `mode` parameter."""
+    def test_deleting_with_no_action(self):
+        """Try to delete data without passing the `action` parameter."""
 
         self.client.force_login(user=self.testuser)
-        result = {"detail": "Non-null query parameter 'mode' is mandatory."}
+        result = {"detail": "Non-null query parameter 'action' is mandatory."}
 
         response = self.client.delete(reverse_lazy("daily_stats"))
         self.assertEqual(response.status_code, HTTP_400_BAD_REQUEST)
         self.assertEqual(response.json(), result)
 
-    def test_deleting_with_nonexistent_mode(self):
-        """Try to delete data with passing an invalid `mode` parameter."""
+    def test_deleting_with_nonexistent_action(self):
+        """Try to delete data with passing an invalid `action` parameter."""
 
         self.client.force_login(user=self.testuser)
-        result = {"detail": "Query parameter 'mode' is not among valid modes."}
+        result = {"detail": "Query parameter 'action' is not among valid actions."}
 
         response = self.client.delete(
-            reverse_lazy("daily_stats"), QUERY_STRING="mode=x"
+            reverse_lazy("daily_stats"), QUERY_STRING="action=x"
         )
         self.assertEqual(response.status_code, HTTP_400_BAD_REQUEST)
         self.assertEqual(response.json(), result)
@@ -349,7 +349,7 @@ class DeleteHistoryStatsTests(APITestCase):
         result = {"deleted": 3}
 
         response = self.client.delete(
-            reverse_lazy("daily_stats"), QUERY_STRING="mode=truncate"
+            reverse_lazy("daily_stats"), QUERY_STRING="action=truncate"
         )
         self.assertEqual(response.status_code, HTTP_200_OK)
         self.assertEqual(response.json(), result)
@@ -362,7 +362,7 @@ class DeleteHistoryStatsTests(APITestCase):
 
         response = self.client.delete(
             reverse_lazy("daily_stats"),
-            QUERY_STRING="mode=delete_older_than&args=2021-01-01",
+            QUERY_STRING="action=delete_older_than&args=2021-01-01",
         )
         self.assertEqual(response.status_code, HTTP_200_OK)
         self.assertEqual(response.json(), result)
@@ -374,7 +374,7 @@ class DeleteHistoryStatsTests(APITestCase):
         result = {"detail": "Argument 'date' in 'args' (0) is mandatory."}
 
         response = self.client.delete(
-            reverse_lazy("daily_stats"), QUERY_STRING="mode=delete_older_than"
+            reverse_lazy("daily_stats"), QUERY_STRING="action=delete_older_than"
         )
         self.assertEqual(response.status_code, HTTP_400_BAD_REQUEST)
         self.assertEqual(response.json(), result)


### PR DESCRIPTION
Renamed the `action` query parameter in history stats to `action` for easier understanding.