### PR TITLE
Bug/column hardcoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Each of these keys contains a list of dictionaries, each representing one column
 Each dictionary is structured as follows:
 
 - `column_name`: The name of the column.
-- `column_type`: The type of the column. Must be either `positive_small_integer`, `small_integer`, `integer`, or `float`.
+- `column_type`: The type of the column. See [here](#column-types) for the possible column types. Must be either `positive_small_integer`, `small_integer`, `integer`, or `float`.
 - `nullable` (optional): Whether to store empty values as null in the database.
 - `default` (optional): Any default value in case the user does not specify any value for a column value.
 - `length` (optional): The length of a specified field. Recommended for `float` fields.
@@ -101,6 +101,17 @@ Each dictionary is structured as follows:
 For the keys `nullable`, `default`, and `length`, a value of `N/A` could be used to indicate an empty value.
 
 Starting with version 2.1.0, keys without a value (`nullable` for instance) can be omitted directly instead of asigning it a value of `N/A`.
+
+#### Column types
+
+| Value | Description |
+| ----- | ---- |
+| `positive_small_integer` | A positive small integer. |
+| `small_integer` | A small integer. |
+| `integer` | An integer. |
+| `float` | A column of type `float`. |
+| `date` | A column which stores a date, like `2023-01-01`. |
+| `datetime` | A column which stores a datetime, like `2023-01-01 00:00:00`. |
 
 ---
 ### Rest API administration

--- a/columns.json
+++ b/columns.json
@@ -188,7 +188,7 @@
   ],
   "solax_daily_details": [
     {
-      "column_name": "upload_time",
+      "column_name": "upload_datetime",
       "column_type": "datetime",
       "primary_key": true
     },

--- a/my_api/settings.py
+++ b/my_api/settings.py
@@ -128,7 +128,7 @@ An API that manipulates data read from a solar inverter. For more details on how
 use it, consult [the documentation](\
 https://github.com/mkfam7/solaxx3_api?tab=readme-ov-file#rest-api-gateway-for-solar-inverter\
 ).""",
-    "VERSION": "2.1.1",
+    "VERSION": "2.1.2",
     "SERVE_INCLUDE_SCHEMA": False,
     "SWAGGER_UI_DIST": "SIDECAR",
     "SWAGGER_UI_FAVICON_HREF": "SIDECAR",

--- a/solax_registers/constants/documentation.py
+++ b/solax_registers/constants/documentation.py
@@ -24,7 +24,7 @@ STATS_PARAM = OpenApiParameter(
         OpenApiExample(
             name="Passing a list of fields",
             summary="Passing list of fields",
-            value=["upload_time", "grid_voltage_r"],
+            value=["upload_datetime", "grid_voltage_r"],
             description="Finally, you can pass a list of fields.",
         ),
     ],

--- a/solax_registers/create_views.py
+++ b/solax_registers/create_views.py
@@ -12,11 +12,10 @@ from rest_framework.serializers import ModelSerializer
 from rest_framework.views import APIView
 
 from .constants import documentation, response_templates
-from .utils import ResponseException, catch400, set_subtract
+from .utils import ResponseException, catch400, get_pk_name_for, set_subtract
 
 
 def create_views(
-    upload_date_column: str,
     model_serializer: Type[ModelSerializer],
     last_record_model_serializer: Type[ModelSerializer],
     docs: Dict[str, str],
@@ -26,8 +25,6 @@ def create_views(
 
     Parameters
     ----------
-    upload_date_column : int
-        column of model representing pushing date.
     model_serializer : rest_framework.serializers.ModelSerializer
         serializer of model.
     last_model_serializer : rest_framework.serializers.ModelSerializer
@@ -44,6 +41,7 @@ def create_views(
     """
 
     use_datetime = not isinstance(model_serializer.Meta.model._meta.pk, DateField)
+    upload_date_column = get_pk_name_for(model_serializer)
     if use_datetime:
         get_parameters = documentation.GET_PARAMETERS
     else:

--- a/solax_registers/tests.py
+++ b/solax_registers/tests.py
@@ -4,6 +4,7 @@ import logging
 import unittest
 
 from django.contrib.auth import get_user_model
+from django.db.models import DateTimeField
 from django.urls import reverse_lazy
 from rest_framework.status import HTTP_200_OK, HTTP_201_CREATED, HTTP_400_BAD_REQUEST
 from rest_framework.test import APITestCase
@@ -12,6 +13,7 @@ from .constants import response_templates
 from .models import DailyStatsRecord, LastDayStatsRecord
 from .utils import (
     get_a_nonexistent_column,
+    get_pk_for,
     get_sample_column_values,
     get_model_field_class,
     read_columns_file,
@@ -20,6 +22,16 @@ from .utils import (
 logging.disable()
 User = get_user_model()
 columns = read_columns_file()
+
+pk_col = get_pk_for(DailyStatsRecord)
+datetime_pk = isinstance(pk_col, DateTimeField)
+pk_name = pk_col.name
+
+
+def _(v):
+    if datetime_pk:
+        return v + "T00:00:00Z"
+    return v
 
 
 class AddHistoryStatsTests(APITestCase):
@@ -42,17 +54,20 @@ class AddHistoryStatsTests(APITestCase):
 
         self.client.force_login(self.testuser)
 
-        data = {"upload_date": "2022-01-01"}
+        data = {pk_name: _("2022-01-01")}
         result = get_sample_column_values(
             columns["daily_stats"],
+            pk_name,
             {
                 "positive_small_integer": None,
                 "small_integer": None,
                 "integer": None,
                 "float": None,
+                "date": None,
+                "datetime": None,
             },
-            {"upload_date": "2022-01-01"},
-            datetime_pk=False,
+            {pk_name: _("2022-01-01")},
+            datetime_pk=datetime_pk,
         )
         url = reverse_lazy("daily_stats", current_app="solax_registers")
         response = self.client.post(url, data=data, format="json")
@@ -81,7 +96,7 @@ class AddHistoryStatsTests(APITestCase):
 
         nonexistent_column = get_a_nonexistent_column()
 
-        data = {"upload_date": "2020-01-01", nonexistent_column: "extra_value"}
+        data = {pk_name: _("2020-01-01"), nonexistent_column: "extra_value"}
 
         url = reverse_lazy("daily_stats", current_app="solax_registers")
         response = self.client.post(url, data=data, format="json")
@@ -126,7 +141,7 @@ class AddHistoryStatsTests(APITestCase):
 
         self.client.force_login(self.testuser)
 
-        data = {"upload_date": "2020-01-01"}
+        data = {pk_name: _("2020-01-01")}
 
         url = reverse_lazy("daily_stats", current_app="solax_registers")
         self.client.post(url, data=data, format="json")
@@ -143,7 +158,7 @@ class AddHistoryStatsTests(APITestCase):
 
         self.client.force_login(self.testuser)
 
-        data = {"upload_date": "2020-01-01"}
+        data = {pk_name: _("2020-01-01")}
 
         url = reverse_lazy("daily_stats", current_app="solax_registers")
         self.client.post(url, data=data, format="json")
@@ -159,7 +174,7 @@ class AddHistoryStatsTests(APITestCase):
         """Test posting data with an invalid `overwrite` parameter."""
 
         self.client.force_login(self.testuser)
-        data = {"upload_date": "2020-01-01"}
+        data = {pk_name: _("2020-01-01")}
 
         url = reverse_lazy("daily_stats", current_app="solax_registers")
         response = self.client.post(
@@ -190,9 +205,54 @@ class GetHistoryStatsTests(APITestCase):
 
         DailyStatsRecord.objects.bulk_create(
             [
-                DailyStatsRecord(upload_date="2020-01-01"),
-                DailyStatsRecord(upload_date="2021-01-01"),
-                DailyStatsRecord(upload_date="2022-01-01"),
+                DailyStatsRecord(
+                    **get_sample_column_values(
+                        columns["daily_stats"],
+                        pk_name,
+                        {
+                            "positive_small_integer": None,
+                            "small_integer": None,
+                            "integer": None,
+                            "float": None,
+                            "date": None,
+                            "datetime": None,
+                        },
+                        {pk_name: _("2020-01-01")},
+                        datetime_pk=datetime_pk,
+                    )
+                ),
+                DailyStatsRecord(
+                    **get_sample_column_values(
+                        columns["daily_stats"],
+                        pk_name,
+                        {
+                            "positive_small_integer": None,
+                            "small_integer": None,
+                            "integer": None,
+                            "float": None,
+                            "date": None,
+                            "datetime": None,
+                        },
+                        {pk_name: _("2021-01-01")},
+                        datetime_pk=datetime_pk,
+                    )
+                ),
+                DailyStatsRecord(
+                    **get_sample_column_values(
+                        columns["daily_stats"],
+                        pk_name,
+                        {
+                            "positive_small_integer": None,
+                            "small_integer": None,
+                            "integer": None,
+                            "float": None,
+                            "date": None,
+                            "datetime": None,
+                        },
+                        {pk_name: _("2022-01-01")},
+                        datetime_pk=datetime_pk,
+                    )
+                ),
             ],
         )
 
@@ -204,36 +264,45 @@ class GetHistoryStatsTests(APITestCase):
         result = [
             get_sample_column_values(
                 columns["daily_stats"],
+                pk_name,
                 {
                     "positive_small_integer": None,
                     "small_integer": None,
                     "integer": None,
                     "float": None,
+                    "date": None,
+                    "datetime": None,
                 },
-                {"upload_date": "2020-01-01"},
-                datetime_pk=False,
+                {pk_name: _("2020-01-01")},
+                datetime_pk=datetime_pk,
             ),
             get_sample_column_values(
                 columns["daily_stats"],
+                pk_name,
                 {
                     "positive_small_integer": None,
                     "small_integer": None,
                     "integer": None,
                     "float": None,
+                    "date": None,
+                    "datetime": None,
                 },
-                {"upload_date": "2021-01-01"},
-                datetime_pk=False,
+                {pk_name: _("2021-01-01")},
+                datetime_pk=datetime_pk,
             ),
             get_sample_column_values(
                 columns["daily_stats"],
+                pk_name,
                 {
                     "positive_small_integer": None,
                     "small_integer": None,
                     "integer": None,
                     "float": None,
+                    "date": None,
+                    "datetime": None,
                 },
-                {"upload_date": "2022-01-01"},
-                datetime_pk=False,
+                {pk_name: _("2022-01-01")},
+                datetime_pk=datetime_pk,
             ),
         ]
 
@@ -282,11 +351,11 @@ class GetHistoryStatsTests(APITestCase):
 
         self.client.force_login(self.testuser)
 
-        result = [{"upload_date": "2020-01-01"}, {"upload_date": "2021-01-01"}]
+        result = [{pk_name: _("2020-01-01")}, {pk_name: _("2021-01-01")}]
 
         response = self.client.get(
             reverse_lazy("daily_stats"),
-            QUERY_STRING="fields=upload_date&before=2021-01-01",
+            QUERY_STRING=f"fields={pk_name}&before=2021-01-01",
         )
         self.assertEqual(response.status_code, HTTP_200_OK)
         self.assertListEqual(response.json(), result)
@@ -296,11 +365,11 @@ class GetHistoryStatsTests(APITestCase):
 
         self.client.force_login(self.testuser)
 
-        result = [{"upload_date": "2021-01-01"}, {"upload_date": "2022-01-01"}]
+        result = [{pk_name: _("2021-01-01")}, {pk_name: _("2022-01-01")}]
 
         response = self.client.get(
             reverse_lazy("daily_stats"),
-            QUERY_STRING="fields=upload_date&since=2021-01-01",
+            QUERY_STRING=f"fields={pk_name}&since=2021-01-01",
         )
         self.assertEqual(response.status_code, HTTP_200_OK)
         self.assertListEqual(response.json(), result)
@@ -310,11 +379,11 @@ class GetHistoryStatsTests(APITestCase):
 
         self.client.force_login(self.testuser)
 
-        result = [{"upload_date": "2021-01-01"}]
+        result = [{pk_name: _("2021-01-01")}]
 
         response = self.client.get(
             reverse_lazy("daily_stats"),
-            QUERY_STRING="fields=upload_date&since=2021-01-01&before=2021-01-01",
+            QUERY_STRING=f"fields={pk_name}&since=2021-01-01&before=2021-01-01",
         )
         self.assertEqual(response.status_code, HTTP_200_OK)
         self.assertListEqual(response.json(), result)
@@ -325,14 +394,14 @@ class GetHistoryStatsTests(APITestCase):
         self.client.force_login(self.testuser)
 
         result = [
-            {"upload_date": "2020-01-01"},
-            {"upload_date": "2021-01-01"},
-            {"upload_date": "2022-01-01"},
+            {pk_name: _("2020-01-01")},
+            {pk_name: _("2021-01-01")},
+            {pk_name: _("2022-01-01")},
         ]
 
         response = self.client.get(
             reverse_lazy("daily_stats"),
-            QUERY_STRING="fields=upload_date&since=0001-01-01",
+            QUERY_STRING=f"fields={pk_name}&since=0001-01-01",
         )
         self.assertEqual(response.status_code, HTTP_200_OK)
         self.assertListEqual(response.json(), result)
@@ -356,9 +425,54 @@ class DeleteHistoryStatsTests(APITestCase):
 
         DailyStatsRecord.objects.bulk_create(
             [
-                DailyStatsRecord(upload_date="2020-01-01"),
-                DailyStatsRecord(upload_date="2021-01-01"),
-                DailyStatsRecord(upload_date="2022-01-01"),
+                DailyStatsRecord(
+                    **get_sample_column_values(
+                        columns["daily_stats"],
+                        pk_name,
+                        {
+                            "positive_small_integer": None,
+                            "small_integer": None,
+                            "integer": None,
+                            "float": None,
+                            "date": None,
+                            "datetime": None,
+                        },
+                        {pk_name: _("2020-01-01")},
+                        datetime_pk=datetime_pk,
+                    )
+                ),
+                DailyStatsRecord(
+                    **get_sample_column_values(
+                        columns["daily_stats"],
+                        pk_name,
+                        {
+                            "positive_small_integer": None,
+                            "small_integer": None,
+                            "integer": None,
+                            "float": None,
+                            "date": None,
+                            "datetime": None,
+                        },
+                        {pk_name: _("2021-01-01")},
+                        datetime_pk=datetime_pk,
+                    )
+                ),
+                DailyStatsRecord(
+                    **get_sample_column_values(
+                        columns["daily_stats"],
+                        pk_name,
+                        {
+                            "positive_small_integer": None,
+                            "small_integer": None,
+                            "integer": None,
+                            "float": None,
+                            "date": None,
+                            "datetime": None,
+                        },
+                        {pk_name: _("2022-01-01")},
+                        datetime_pk=datetime_pk,
+                    )
+                ),
             ]
         )
 
@@ -435,7 +549,22 @@ class GetLastHistoryStatsTests(APITestCase):
             is_superuser=True,
         )
         cls.testuser = User.objects.get(username="testuser")
-        LastDayStatsRecord(upload_date="2020-01-01").save()
+        LastDayStatsRecord(
+            **get_sample_column_values(
+                columns["daily_stats"],
+                pk_name,
+                {
+                    "positive_small_integer": None,
+                    "small_integer": None,
+                    "integer": None,
+                    "float": None,
+                    "date": None,
+                    "datetime": None,
+                },
+                {pk_name: _("2020-01-01")},
+                datetime_pk=datetime_pk,
+            )
+        ).save()
 
     def test_get_all_data(self):
         """Try to get all data."""
@@ -444,14 +573,17 @@ class GetLastHistoryStatsTests(APITestCase):
 
         result = get_sample_column_values(
             columns["daily_stats"],
+            pk_name,
             {
                 "positive_small_integer": None,
                 "small_integer": None,
                 "integer": None,
                 "float": None,
+                "date": None,
+                "datetime": None,
             },
-            {"upload_date": "2020-01-01"},
-            datetime_pk=False,
+            {pk_name: _("2020-01-01")},
+            datetime_pk=datetime_pk,
         )
 
         response = self.client.get(reverse_lazy("daily_stats"))
@@ -480,11 +612,11 @@ class GetLastHistoryStatsTests(APITestCase):
 
         self.client.force_login(self.testuser)
 
-        result = {"upload_date": "2020-01-01"}
+        result = {pk_name: _("2020-01-01")}
 
         response = self.client.get(
             reverse_lazy("daily_stats"),
-            QUERY_STRING="fields=upload_date",
+            QUERY_STRING=f"fields={pk_name}",
         )
         self.assertEqual(response.status_code, HTTP_200_OK)
         self.assertDictEqual(response.json(), result)

--- a/solax_registers/utils.py
+++ b/solax_registers/utils.py
@@ -1,3 +1,4 @@
+import datetime
 from functools import wraps
 import json
 from operator import itemgetter
@@ -226,11 +227,14 @@ def _rename(d: dict, old: str, new: str) -> None:
 
 def get_sample_column_values(
     column_info,
+    pk,
     column_type_fallbacks={
         "positive_small_integer": 0,
         "small_integer": -1,
         "integer": 0,
         "float": 0.6,
+        "date": datetime.datetime.now().date(),
+        "datetime": datetime.datetime.now(),
     },
     column_values={},
     datetime_pk=True,
@@ -246,11 +250,10 @@ def get_sample_column_values(
         elif column_type in column_type_fallbacks:
             result[name] = column_type_fallbacks[column_type]
 
-    date_column = "upload_time" if datetime_pk else "upload_date"
     date_value = column_values.get(
-        date_column, "2022-01-01 00:00" if datetime_pk else "2022-01-01"
+        pk, "2022-01-01 00:00" if datetime_pk else "2022-01-01"
     )
-    result[date_column] = date_value
+    result[pk] = date_value
     return result
 
 
@@ -290,3 +293,14 @@ def catch400(func):
             return exc.args[0]
 
     return inner
+
+
+def get_pk_for(model_or_serializer):
+    try:
+        return model_or_serializer._meta.pk
+    except:
+        return model_or_serializer.Meta.model._meta.pk
+
+
+def get_pk_name_for(model_or_serializer):
+    return get_pk_for(model_or_serializer).name

--- a/solax_registers/views.py
+++ b/solax_registers/views.py
@@ -18,7 +18,6 @@ from .serializers import (
 )
 
 DailyStats = create_views(
-    upload_date_column="upload_date",
     model_serializer=DailyStatsSerializer,
     last_record_model_serializer=LastDayStatsSerializer,
     docs={
@@ -30,7 +29,6 @@ DailyStats = create_views(
 
 
 DailyDetails = create_views(
-    upload_date_column="upload_time",
     model_serializer=DailyDetailsSerializer,
     last_record_model_serializer=LastDayDetailsSerializer,
     docs={
@@ -41,7 +39,6 @@ DailyDetails = create_views(
 )
 
 MinuteStats = create_views(
-    upload_date_column="upload_time",
     model_serializer=MinuteStatsSerializer,
     last_record_model_serializer=LastMinuteStatsSerializer,
     docs={


### PR DESCRIPTION
Fixed a bug that did not allow the renaming of the primary keys to other than their original names in previous versions (`upload_time` and `upload_date`)